### PR TITLE
Add DIFT taint tracking toward partial SSE instruction set.

### DIFF
--- a/ext/dift/dift-policy-head.h
+++ b/ext/dift/dift-policy-head.h
@@ -28,7 +28,7 @@
     CONTAMINATION_RECORD t = 0;
 
 #if defined(CONFIG_DIFT_DEBUG)
-    uint64_t dt, st;
+    uint64_t dt[2], st[2];
 #endif
 
     static void* dispatch[128];
@@ -105,6 +105,39 @@
         dispatch[MEM_IM_CLEAR_MO16] = &&rt_mem_im_clear_mo16;
         dispatch[MEM_IM_CLEAR_MO32] = &&rt_mem_im_clear_mo32;
         dispatch[MEM_IM_CLEAR_MO64] = &&rt_mem_im_clear_mo64;
+
+        // SSE
+        dispatch[XMM_XMM_OO_ASSIGN_MO32] = &&rt_xmm_xmm_oo_assign_mo32;
+        dispatch[XMM_XMM_OO_ASSIGN_MO64] = &&rt_xmm_xmm_oo_assign_mo64;
+        dispatch[XMM_XMM_OO_ASSIGN_MO64LH] = &&rt_xmm_xmm_oo_assign_mo64lh;
+        dispatch[XMM_XMM_OO_ASSIGN_MO64HL] = &&rt_xmm_xmm_oo_assign_mo64hl;
+        dispatch[XMM_XMM_OO_ASSIGN_MO128] = &&rt_xmm_xmm_oo_assign_mo128;
+
+        dispatch[XMM_REG_OO_ASSIGN_MO32] = &&rt_xmm_reg_oo_assign_mo32;
+        dispatch[XMM_REG_OO_ASSIGN_MO64] = &&rt_xmm_reg_oo_assign_mo64;
+
+        dispatch[REG_XMM_OO_ASSIGN_MO32] = &&rt_reg_xmm_oo_assign_mo32;
+        dispatch[REG_XMM_OO_ASSIGN_MO64] = &&rt_reg_xmm_oo_assign_mo64;
+
+        dispatch[XMM_MEM_OO_ASSIGN_MO32] = &&rt_xmm_mem_oo_assign_mo32;
+        dispatch[XMM_MEM_OO_ASSIGN_MO64] = &&rt_xmm_mem_oo_assign_mo64;
+        dispatch[XMM_MEM_OO_ASSIGN_MO64H] = &&rt_xmm_mem_oo_assign_mo64h;
+        dispatch[XMM_MEM_OO_ASSIGN_MO128] = &&rt_xmm_mem_oo_assign_mo128;
+
+        dispatch[MEM_XMM_OO_ASSIGN_MO32] = &&rt_mem_xmm_oo_assign_mo32;
+        dispatch[MEM_XMM_OO_ASSIGN_MO64] = &&rt_mem_xmm_oo_assign_mo64;
+        dispatch[MEM_XMM_OO_ASSIGN_MO64H] = &&rt_mem_xmm_oo_assign_mo64h;
+        dispatch[MEM_XMM_OO_ASSIGN_MO128] = &&rt_mem_xmm_oo_assign_mo128;
+
+        dispatch[XMM_XMM_OO_ASSIGN_DUP_MO32L] = &&rt_xmm_xmm_oo_assign_dup_mo32l;
+        dispatch[XMM_XMM_OO_ASSIGN_DUP_MO32H] = &&rt_xmm_xmm_oo_assign_dup_mo32h;
+        dispatch[XMM_XMM_OO_ASSIGN_DUP_MO64] = &&rt_xmm_xmm_oo_assign_dup_mo64;
+
+        dispatch[XMM_MEM_OO_ASSIGN_DUP_MO32L] = &&rt_xmm_mem_oo_assign_dup_mo32l;
+        dispatch[XMM_MEM_OO_ASSIGN_DUP_MO32H] = &&rt_xmm_mem_oo_assign_dup_mo32h;
+        dispatch[XMM_MEM_OO_ASSIGN_DUP_MO64] = &&rt_xmm_mem_oo_assign_dup_mo64;
+
+        dispatch[XMM_IM_CLEAR] = &&rt_xmm_im_clear;
 
         dispatch[MEM_HD] = &&rt_mem_hd;
         dispatch[HD_MEM] = &&rt_hd_mem;

--- a/ext/dift/dift-policy.h
+++ b/ext/dift/dift-policy.h
@@ -26,20 +26,20 @@ rt_inside_reg_assign:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = dc->reg_dirty_tbl[i][j];
-    st = dc->reg_dirty_tbl[i][l];
+    dt[0] = dc->reg_dirty_tbl[i][j];
+    st[0] = dc->reg_dirty_tbl[i][l];
 
     dift_log( "B I %s%s[%d](%" PRIx64 ") %s%s %s%s[%d](%" PRIx64 ")", 
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
                 j,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
                 l,
-                st );
+                st[0]);
 }
 #endif
 
@@ -63,20 +63,20 @@ rt_inside_reg_append:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = dc->reg_dirty_tbl[i][j];
-    st = dc->reg_dirty_tbl[i][l];
+    dt[0] = dc->reg_dirty_tbl[i][j];
+    st[0] = dc->reg_dirty_tbl[i][l];
 
     dift_log( "B I %s%s[%d](%" PRIx64 ") %s%s %s%s[%d](%" PRIx64 ")", 
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
                 j,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
                 l,
-                st );
+                st[0] );
 }
 #endif
 
@@ -101,20 +101,20 @@ rt_reg_reg_oo_assign_mo8:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = dc->reg_dirty_tbl[i][k];
-    st = dc->reg_dirty_tbl[j][l];
+    dt[0] = dc->reg_dirty_tbl[i][k];
+    st[0] = dc->reg_dirty_tbl[j][l];
 
     dift_log( "B O %s%s[%d](%" PRIx64 ") %s%s %s%s[%d](%" PRIx64 ")", 
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
                 k,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[j],
                 l,
-                st );
+                st[0] );
 }
 #endif
 
@@ -137,18 +137,18 @@ rt_reg_reg_oo_assign_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint16_t*)&dc->reg_dirty_tbl[j][0];
+    dt[0] = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint16_t*)&dc->reg_dirty_tbl[j][0];
 
     dift_log( "W O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[j],
-                st );
+                st[0] );
 }
 #endif
 
@@ -171,18 +171,18 @@ rt_reg_reg_oo_assign_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint32_t*)&dc->reg_dirty_tbl[j][0];
+    dt[0] = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint32_t*)&dc->reg_dirty_tbl[j][0];
 
     dift_log( "D O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[j],
-                st );
+                st[0] );
 }
 #endif
 
@@ -205,18 +205,18 @@ rt_reg_reg_oo_assign_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint64_t*)&dc->reg_dirty_tbl[j][0];
+    dt[0] = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint64_t*)&dc->reg_dirty_tbl[j][0];
 
     dift_log( "Q O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[j],
-                st );
+                st[0] );
 }
 #endif
 
@@ -241,20 +241,20 @@ rt_reg_reg_oo_append_mo8:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = dc->reg_dirty_tbl[i][k];
-    st = dc->reg_dirty_tbl[j][l];
+    dt[0] = dc->reg_dirty_tbl[i][k];
+    st[0] = dc->reg_dirty_tbl[j][l];
 
     dift_log( "B O %s%s[%d](%" PRIx64 ") %s%s %s%s[%d](%" PRIx64 ")", 
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
                 k,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[j],
                 l,
-                st );
+                st[0] );
 }
 #endif
 
@@ -277,18 +277,18 @@ rt_reg_reg_oo_append_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint16_t*)&dc->reg_dirty_tbl[j][0];
+    dt[0] = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint16_t*)&dc->reg_dirty_tbl[j][0];
 
     dift_log( "W O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[j],
-                st );
+                st[0] );
 }
 #endif
 
@@ -311,18 +311,18 @@ rt_reg_reg_oo_append_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint32_t*)&dc->reg_dirty_tbl[j][0];
+    dt[0] = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint32_t*)&dc->reg_dirty_tbl[j][0];
 
     dift_log( "D O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[j],
-                st );
+                st[0] );
 }
 #endif
 
@@ -345,18 +345,18 @@ rt_reg_reg_oo_append_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint64_t*)&dc->reg_dirty_tbl[j][0];
+    dt[0] = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint64_t*)&dc->reg_dirty_tbl[j][0];
 
     dift_log( "Q O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[j],
-                st );
+                st[0] );
 }
 #endif
 
@@ -379,18 +379,18 @@ rt_reg_reg_mix_append_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint16_t*)&dc->reg_dirty_tbl[j][0];
+    dt[0] = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint16_t*)&dc->reg_dirty_tbl[j][0];
 
     dift_log( "W M %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")", 
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[j],
-                st );
+                st[0] );
 }
 #endif
 
@@ -417,18 +417,18 @@ rt_reg_reg_mix_append_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint32_t*)&dc->reg_dirty_tbl[j][0];
+    dt[0] = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint32_t*)&dc->reg_dirty_tbl[j][0];
 
     dift_log( "D M %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")", 
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[j],
-                st );
+                st[0] );
 }
 #endif
 
@@ -458,18 +458,18 @@ rt_reg_reg_mix_append_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint64_t*)&dc->reg_dirty_tbl[j][0];
+    dt[0] = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint64_t*)&dc->reg_dirty_tbl[j][0];
 
     dift_log( "Q M %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")", 
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[j],
-                st );
+                st[0] );
 }
 #endif
 
@@ -510,19 +510,19 @@ rt_reg_mem_oo_assign_mo8:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = dc->reg_dirty_tbl[i][k];
-    st = dc->mem_dirty_tbl[ra];
+    dt[0] = dc->reg_dirty_tbl[i][k];
+    st[0] = dc->mem_dirty_tbl[ra];
 
     dift_log( "B O %s%s[%d](%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
                 k,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -557,18 +557,18 @@ rt_reg_mem_oo_assign_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint16_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint16_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "W O %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -605,18 +605,18 @@ rt_reg_mem_oo_assign_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint32_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint32_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "D O %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -640,18 +640,18 @@ rt_reg_mem_oo_assign_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint64_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint64_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "Q O %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -676,19 +676,19 @@ rt_reg_mem_oo_append_mo8:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = dc->reg_dirty_tbl[i][k];
-    st = dc->mem_dirty_tbl[ra];
+    dt[0] = dc->reg_dirty_tbl[i][k];
+    st[0] = dc->mem_dirty_tbl[ra];
 
     dift_log( "B O %s%s[%d](%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
                 k,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }               
 #endif
 
@@ -713,18 +713,18 @@ rt_reg_mem_oo_append_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint16_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint16_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "W O %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -748,18 +748,18 @@ rt_reg_mem_oo_append_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint32_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint32_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "D O %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -783,18 +783,18 @@ rt_reg_mem_oo_append_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint64_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint64_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "Q O %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -818,18 +818,18 @@ rt_reg_mem_mix_assign_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint16_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint16_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "W M %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -855,18 +855,18 @@ rt_reg_mem_mix_assign_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint32_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint32_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "D M %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -896,18 +896,18 @@ rt_reg_mem_mix_assign_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint64_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint64_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "Q M %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -943,18 +943,18 @@ rt_reg_mem_mix_append_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint16_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint16_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "W M %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -981,18 +981,18 @@ rt_reg_mem_mix_append_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint32_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint32_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "D M %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -1021,18 +1021,18 @@ rt_reg_mem_mix_append_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
-    st = *(uint64_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint64_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "Q M %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -1070,19 +1070,19 @@ rt_mem_reg_oo_assign_mo8:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = dc->mem_dirty_tbl[wa];
-    st = dc->reg_dirty_tbl[i][k];
+    dt[0] = dc->mem_dirty_tbl[wa];
+    st[0] = dc->reg_dirty_tbl[i][k];
 
     dift_log( "B O %s[%p](%" PRIx64 ") %s%s %s%s[%d](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
                 k,
-                st );
+                st[0] );
 }
 #endif
 
@@ -1106,18 +1106,18 @@ rt_mem_reg_oo_assign_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint16_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "W O %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa, 
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                st );
+                st[0] );
 }
 #endif
 
@@ -1141,18 +1141,18 @@ rt_mem_reg_oo_assign_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint32_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "D O %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa, 
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                st );
+                st[0] );
 }
 #endif
 
@@ -1176,18 +1176,18 @@ rt_mem_reg_oo_assign_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint64_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "Q O %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa, 
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                st );
+                st[0] );
 }
 #endif
 
@@ -1212,19 +1212,19 @@ rt_mem_reg_oo_append_mo8:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = dc->mem_dirty_tbl[wa];
-    st = dc->reg_dirty_tbl[i][k];
+    dt[0] = dc->mem_dirty_tbl[wa];
+    st[0] = dc->reg_dirty_tbl[i][k];
 
     dift_log( "B O %s[%p](%" PRIx64 ") %s%s %s%s[%d](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
                 k,
-                st );
+                st[0] );
 }
 #endif
 
@@ -1248,18 +1248,18 @@ rt_mem_reg_oo_append_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint16_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "W O %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa, 
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                st );
+                st[0] );
 }
 #endif
 
@@ -1283,18 +1283,18 @@ rt_mem_reg_oo_append_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint32_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "D O %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa, 
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                st );
+                st[0] );
 }
 #endif
 
@@ -1318,18 +1318,18 @@ rt_mem_reg_oo_append_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint64_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "Q O %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa, 
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                st );
+                st[0] );
 }
 #endif
 
@@ -1353,18 +1353,18 @@ rt_mem_reg_mix_assign_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint16_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "W M %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                st );
+                st[0] );
 }
 #endif
 
@@ -1391,18 +1391,18 @@ rt_mem_reg_mix_assign_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint32_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "D M %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                st );
+                st[0] );
 }
 #endif
 
@@ -1432,18 +1432,18 @@ rt_mem_reg_mix_assign_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint64_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "Q M %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                st );
+                st[0] );
 }
 #endif
 
@@ -1479,18 +1479,18 @@ rt_mem_reg_mix_append_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint16_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "W M %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                st );
+                st[0] );
 }
 #endif
 
@@ -1518,18 +1518,18 @@ rt_mem_reg_mix_append_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint32_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "D M %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                st );
+                st[0] );
 }
 #endif
 
@@ -1561,18 +1561,18 @@ rt_mem_reg_mix_append_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint64_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "Q M %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_APPEND,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                st );
+                st[0] );
 }
 #endif
 
@@ -1613,18 +1613,18 @@ rt_mem_mem_oo_assign_mo8:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = dc->mem_dirty_tbl[wa];
-    st = dc->mem_dirty_tbl[ra];
+    dt[0] = dc->mem_dirty_tbl[wa];
+    st[0] = dc->mem_dirty_tbl[ra];
 
     dift_log( "B O %s[%p](%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -1649,18 +1649,18 @@ rt_mem_mem_oo_assign_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint16_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint16_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint16_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "W O %s[%p](%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -1685,18 +1685,18 @@ rt_mem_mem_oo_assign_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint32_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint32_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint32_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "D O %s[%p](%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -1721,18 +1721,18 @@ rt_mem_mem_oo_assign_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->mem_dirty_tbl[wa];
-    st = *(uint64_t*)&dc->mem_dirty_tbl[ra];
+    dt[0] = *(uint64_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint64_t*)&dc->mem_dirty_tbl[ra];
 
     dift_log( "Q O %s[%p](%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt,
+                dt[0],
                 DIFT_DEBUG_COLOR_OPERATOR,
                 DIFT_DEBUG_OP_ASSIGN,
-                (st) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 ra,
-                st );
+                st[0] );
 }
 #endif
 
@@ -1755,13 +1755,13 @@ rt_reg_im_clear_mo8:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = dc->reg_dirty_tbl[i][k];
+    dt[0] = dc->reg_dirty_tbl[i][k];
 
     dift_log( "B C %s%s[%d](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
                 k,
-                dt );
+                dt[0] );
 }
 #endif
 
@@ -1783,12 +1783,12 @@ rt_reg_im_clear_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint16_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "W C %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt );
+                dt[0] );
 }
 #endif
 
@@ -1810,12 +1810,12 @@ rt_reg_im_clear_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "D C %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt );
+                dt[0] );
 }
 #endif
 
@@ -1837,12 +1837,12 @@ rt_reg_im_clear_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
+    dt[0] = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
 
     dift_log( "Q C %s%s(%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 REG_NAME[i],
-                dt );
+                dt[0] );
 }
 #endif
 
@@ -1865,12 +1865,12 @@ rt_mem_im_clear_mo8:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = dc->mem_dirty_tbl[wa];
+    dt[0] = dc->mem_dirty_tbl[wa];
 
     dift_log( "B C %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt );
+                dt[0] );
 }
 #endif
 
@@ -1893,12 +1893,12 @@ rt_mem_im_clear_mo16:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint16_t*)&dc->mem_dirty_tbl[wa];
+    dt[0] = *(uint16_t*)&dc->mem_dirty_tbl[wa];
 
     dift_log( "W C %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt );
+                dt[0] );
 }
 #endif
 
@@ -1921,12 +1921,12 @@ rt_mem_im_clear_mo32:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint32_t*)&dc->mem_dirty_tbl[wa];
+    dt[0] = *(uint32_t*)&dc->mem_dirty_tbl[wa];
 
     dift_log( "D C %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt );
+                dt[0] );
 }
 #endif
 
@@ -1949,12 +1949,12 @@ rt_mem_im_clear_mo64:
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
 {
-    dt = *(uint64_t*)&dc->mem_dirty_tbl[wa];
+    dt[0] = *(uint64_t*)&dc->mem_dirty_tbl[wa];
 
     dift_log( "Q C %s[%p](%" PRIx64 ")",
-                (dt) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+                (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
                 wa,
-                dt );
+                dt[0] );
 }
 #endif
 
@@ -1962,6 +1962,871 @@ DIFT_DEBUG_CONDITION
 
 #if defined(CONFIG_DIFT_DEBUG)
 DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR 
+              DIFT_DEBUG_OP_COMPLETE 
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+// SSE
+rt_xmm_xmm_oo_assign_mo32:
+    i = rec.v1.r2r.dreg;
+    j = rec.v1.r2r.sreg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint32_t*)&dc->xmm_dirty_tbl[i][0];
+    st[0] = *(uint32_t*)&dc->xmm_dirty_tbl[j][0];
+
+    dift_log( "D O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
+            (dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[j],
+            st[0] );
+}
+#endif
+    
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][0] = *(uint32_t*)&dc->xmm_dirty_tbl[j][0];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_xmm_oo_assign_mo64:
+    i = rec.v1.r2r.dreg;
+    j = rec.v1.r2r.sreg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+    st[0] = *(uint64_t*)&dc->xmm_dirty_tbl[j][0];
+
+    dift_log( "Q O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
+            (dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[j],
+            st[0] );
+}
+#endif
+    
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][0] = *(uint64_t*)&dc->xmm_dirty_tbl[j][0];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_xmm_oo_assign_mo64lh:
+    i = rec.v1.r2r.dreg;
+    j = rec.v1.r2r.sreg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][8];
+    st[0] = *(uint64_t*)&dc->xmm_dirty_tbl[j][0];
+
+    dift_log( "Q O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ") L2H",
+            (dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[j],
+            st[0] );
+}
+#endif
+    
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][8] = *(uint64_t*)&dc->xmm_dirty_tbl[j][0];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_xmm_oo_assign_mo64hl:
+    i = rec.v1.r2r.dreg;
+    j = rec.v1.r2r.sreg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+    st[0] = *(uint64_t*)&dc->xmm_dirty_tbl[j][8];
+
+    dift_log( "Q O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ") H2L",
+            (dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[j],
+            st[0] );
+}
+#endif
+    
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][0] = *(uint64_t*)&dc->xmm_dirty_tbl[j][8];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_xmm_oo_assign_mo128:
+    i = rec.v1.r2r.dreg;
+    j = rec.v1.r2r.sreg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+    dt[1] = *(uint64_t*)&dc->xmm_dirty_tbl[i][8];
+
+    st[0] = *(uint64_t*)&dc->xmm_dirty_tbl[j][0];
+    st[1] = *(uint64_t*)&dc->xmm_dirty_tbl[j][8];
+
+    dift_log( "DQ O %s%s(%" PRIx64 "%" PRIx64 ") %s%s %s%s(%" PRIx64 "%" PRIx64 ")",
+            (dt[0] | dt[1])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[1], dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0] | st[1])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[j],
+            st[1], st[0] );
+}
+#endif
+    
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][0] = *(uint64_t*)&dc->xmm_dirty_tbl[j][0];
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][8] = *(uint64_t*)&dc->xmm_dirty_tbl[j][8];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_reg_oo_assign_mo32:
+    i = rec.v1.r2r.dreg;
+    j = rec.v1.r2r.sreg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint32_t*)&dc->xmm_dirty_tbl[i][0];
+    st[0] = *(uint32_t*)&dc->reg_dirty_tbl[j][0];
+
+    dift_log( "D O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
+            (dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            REG_NAME[j],
+            st[0] );
+}
+#endif
+    
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][0] = *(uint32_t*)&dc->reg_dirty_tbl[j][0];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_reg_oo_assign_mo64:
+    i = rec.v1.r2r.dreg;
+    j = rec.v1.r2r.sreg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+    st[0] = *(uint64_t*)&dc->reg_dirty_tbl[j][0];
+
+    dift_log( "Q O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
+            (dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            REG_NAME[j],
+            st[0] );
+}
+#endif
+    
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][0] = *(uint64_t*)&dc->reg_dirty_tbl[j][0];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_reg_xmm_oo_assign_mo32:
+    i = rec.v1.r2r.dreg;
+    j = rec.v1.r2r.sreg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint32_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint32_t*)&dc->xmm_dirty_tbl[j][0];
+
+    dift_log( "D O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
+            (dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            REG_NAME[i],
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[j],
+            st[0] );
+}
+#endif
+    
+    *(uint32_t*)&dc->reg_dirty_tbl[i][0] = *(uint32_t*)&dc->xmm_dirty_tbl[j][0];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_reg_xmm_oo_assign_mo64:
+    i = rec.v1.r2r.dreg;
+    j = rec.v1.r2r.sreg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->reg_dirty_tbl[i][0];
+    st[0] = *(uint64_t*)&dc->xmm_dirty_tbl[j][0];
+
+    dift_log( "Q O %s%s(%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
+            (dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            REG_NAME[i],
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[j],
+            st[0] );
+}
+#endif
+    
+    *(uint64_t*)&dc->reg_dirty_tbl[i][0] = *(uint64_t*)&dc->xmm_dirty_tbl[j][0];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_mem_oo_assign_mo32:
+    ra = DEQ_FROM_ADDR();
+    ra = (ra < phys_ram_size) ? ra : clean_source;
+    i = rec.v1.r2m_m2r.reg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint32_t*)&dc->xmm_dirty_tbl[i][0];
+    st[0] = *(uint32_t*)&dc->mem_dirty_tbl[ra];
+
+    dift_log( "D O %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
+            (dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            ra,
+            st[0] );
+}
+#endif
+
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][0] = *(uint32_t*)&dc->mem_dirty_tbl[ra];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_mem_oo_assign_mo64:
+    ra = DEQ_FROM_ADDR();
+    ra = (ra < phys_ram_size) ? ra : clean_source;
+    i = rec.v1.r2m_m2r.reg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+    st[0] = *(uint64_t*)&dc->mem_dirty_tbl[ra];
+
+    dift_log( "Q O %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ")",
+            (dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            ra,
+            st[0] );
+}
+#endif
+
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][0] = *(uint64_t*)&dc->mem_dirty_tbl[ra];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_mem_oo_assign_mo64h:
+    ra = DEQ_FROM_ADDR();
+    ra = (ra < phys_ram_size) ? ra : clean_source;
+    i = rec.v1.r2m_m2r.reg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][8];
+    st[0] = *(uint64_t*)&dc->mem_dirty_tbl[ra];
+
+    dift_log( "Q O %s%s(%" PRIx64 ") %s%s %s[%p](%" PRIx64 ") H",
+            (dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            ra,
+            st[0] );
+}
+#endif
+
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][8] = *(uint64_t*)&dc->mem_dirty_tbl[ra];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_mem_oo_assign_mo128:
+    ra = DEQ_FROM_ADDR();
+    ra = (ra < phys_ram_size) ? ra : clean_source;
+    i = rec.v1.r2m_m2r.reg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+    dt[1] = *(uint64_t*)&dc->xmm_dirty_tbl[i][8];
+
+    st[0] = *(uint64_t*)&dc->mem_dirty_tbl[ra];
+    st[1] = (ra + 8 < phys_ram_size)? *(uint64_t*)&dc->mem_dirty_tbl[ra + 8] : 0;
+
+    dift_log( "DQ O %s%s(%" PRIx64 "%" PRIx64 ") %s%s %s[%p](%" PRIx64 "%" PRIx64 ")",
+            (dt[1] | dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[1], dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[1] | st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            ra,
+            st[1], st[0] );
+}
+#endif
+
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][0] = *(uint64_t*)&dc->mem_dirty_tbl[ra];
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][8] = *(uint64_t*)&dc->mem_dirty_tbl[ra + 8];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_mem_xmm_oo_assign_mo32:
+    wa = DEQ_FROM_ADDR();
+    wa = (wa < phys_ram_size) ? wa : null_sink;
+    i = rec.v1.r2m_m2r.reg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint32_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint32_t*)&dc->xmm_dirty_tbl[i][0];
+
+    dift_log( "D O %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
+            (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            wa,
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            st[0] );
+}            
+#endif
+
+    *(uint32_t*)&dc->mem_dirty_tbl[wa] = *(uint32_t*)&dc->xmm_dirty_tbl[i][0];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_mem_xmm_oo_assign_mo64:
+    wa = DEQ_FROM_ADDR();
+    wa = (wa < phys_ram_size) ? wa : null_sink;
+    i = rec.v1.r2m_m2r.reg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+
+    dift_log( "Q O %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ")",
+            (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            wa,
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            st[0] );
+}            
+#endif
+
+    *(uint64_t*)&dc->mem_dirty_tbl[wa] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_mem_xmm_oo_assign_mo64h:
+    wa = DEQ_FROM_ADDR();
+    wa = (wa < phys_ram_size) ? wa : null_sink;
+    i = rec.v1.r2m_m2r.reg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->mem_dirty_tbl[wa];
+    st[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][8];
+
+    dift_log( "Q O %s[%p](%" PRIx64 ") %s%s %s%s(%" PRIx64 ") H",
+            (dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            wa,
+            dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            st[0] );
+}            
+#endif
+
+    *(uint64_t*)&dc->mem_dirty_tbl[wa] = *(uint64_t*)&dc->xmm_dirty_tbl[i][8];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_mem_xmm_oo_assign_mo128:
+    wa = DEQ_FROM_ADDR();
+    wa = (wa < phys_ram_size) ? wa : null_sink;
+    i = rec.v1.r2m_m2r.reg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->mem_dirty_tbl[wa];
+    dt[1] = (wa + 8 < phys_ram_size) ? *(uint64_t*)&dc->mem_dirty_tbl[wa + 8] : 0;
+
+    st[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+    st[1] = *(uint64_t*)&dc->xmm_dirty_tbl[i][1];
+
+    dift_log( "DQ O %s[%p](%" PRIx64 "%" PRIx64 ") %s%s %s%s(%" PRIx64 "%" PRIx64 ")",
+            (dt[1] | dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            wa,
+            dt[1], dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[1] | st[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            st[1], st[0] );
+}            
+#endif
+
+    *(uint64_t*)&dc->mem_dirty_tbl[wa] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+    *(uint64_t*)&dc->mem_dirty_tbl[wa + 8] = *(uint64_t*)&dc->xmm_dirty_tbl[i][8];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_xmm_oo_assign_dup_mo32l:
+    i = rec.v1.r2r.dreg;
+    j = rec.v1.r2r.sreg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[0];
+    dt[1] = *(uint64_t*)&dc->xmm_dirty_tbl[8];
+
+    st[0] = *(uint32_t*)&dc->xmm_dirty_tbl[0];
+    st[1] = *(uint32_t*)&dc->xmm_dirty_tbl[8];
+
+    dift_log( "Q O %s%s(%" PRIx64 "%" PRIx64 ") %s%s %s%s(%" PRIx64 "%" PRIx64 ") LD",
+            (dt[1] | dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[1], dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[1] | st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[j],
+            st[1], st[0] );
+}
+#endif
+
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][0] = *(uint32_t*)&dc->xmm_dirty_tbl[j][0];
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][4] = *(uint32_t*)&dc->xmm_dirty_tbl[j][0];
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][8] = *(uint32_t*)&dc->xmm_dirty_tbl[j][8];
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][12] = *(uint32_t*)&dc->xmm_dirty_tbl[j][8];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_xmm_oo_assign_dup_mo32h:
+    i = rec.v1.r2r.dreg;
+    j = rec.v1.r2r.sreg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[0];
+    dt[1] = *(uint64_t*)&dc->xmm_dirty_tbl[8];
+
+    st[0] = *(uint32_t*)&dc->xmm_dirty_tbl[4];
+    st[1] = *(uint32_t*)&dc->xmm_dirty_tbl[12];
+
+    dift_log( "Q O %s%s(%" PRIx64 "%" PRIx64 ") %s%s %s%s(%" PRIx64 "%" PRIx64 ") HD",
+            (dt[1] | dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[1], dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[1] | st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[j],
+            st[1], st[0] );
+}
+#endif
+
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][0] = *(uint32_t*)&dc->xmm_dirty_tbl[j][4];
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][4] = *(uint32_t*)&dc->xmm_dirty_tbl[j][4];
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][8] = *(uint32_t*)&dc->xmm_dirty_tbl[j][12];
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][12] = *(uint32_t*)&dc->xmm_dirty_tbl[j][12];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_xmm_oo_assign_dup_mo64:
+    i = rec.v1.r2r.dreg;
+    j = rec.v1.r2r.sreg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[0];
+    dt[1] = *(uint64_t*)&dc->xmm_dirty_tbl[8];
+
+    st[0] = *(uint64_t*)&dc->xmm_dirty_tbl[0];
+
+    dift_log( "Q O %s%s(%" PRIx64 "%" PRIx64 ") %s%s %s%s(%" PRIx64 ") LD",
+            (dt[1] | dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[1], dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[j],
+            st[0] );
+}
+#endif
+
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][0] = *(uint64_t*)&dc->xmm_dirty_tbl[j][0];
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][8] = *(uint64_t*)&dc->xmm_dirty_tbl[j][0];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_mem_oo_assign_dup_mo32l:
+    ra = DEQ_FROM_ADDR();
+    ra = (ra < phys_ram_size) ? ra : clean_source;
+    i = rec.v1.r2m_m2r.reg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+    dt[1] = *(uint64_t*)&dc->xmm_dirty_tbl[i][8];
+
+    st[0] = *(uint32_t*)&dc->mem_dirty_tbl[ra];
+    st[1] = *(uint32_t*)&dc->mem_dirty_tbl[ra + 8];
+
+    dift_log( "D O %s%s(%" PRIx64 "%" PRIx64 ") %s%s %s[%p](%" PRIx64 "%" PRIx64 ") LD",
+            (dt[1] | dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[1], dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[1] | st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            ra,
+            st[1], st[0] );
+}
+#endif
+
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][0] = *(uint32_t*)&dc->mem_dirty_tbl[ra];
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][4] = *(uint32_t*)&dc->mem_dirty_tbl[ra];
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][8] = *(uint32_t*)&dc->mem_dirty_tbl[ra + 8];
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][12] = *(uint32_t*)&dc->mem_dirty_tbl[ra + 8];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_mem_oo_assign_dup_mo32h:
+    ra = DEQ_FROM_ADDR();
+    ra = (ra < phys_ram_size) ? ra : clean_source;
+    i = rec.v1.r2m_m2r.reg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+    dt[1] = *(uint64_t*)&dc->xmm_dirty_tbl[i][8];
+
+    st[0] = *(uint32_t*)&dc->mem_dirty_tbl[ra + 4];
+    st[1] = *(uint32_t*)&dc->mem_dirty_tbl[ra + 12];
+
+    dift_log( "D O %s%s(%" PRIx64 "%" PRIx64 ") %s%s %s[%p](%" PRIx64 "%" PRIx64 ") HD",
+            (dt[1] | dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[1], dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[1] | st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            ra,
+            st[1], st[0] );
+}
+#endif
+
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][0] = *(uint32_t*)&dc->mem_dirty_tbl[ra + 4];
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][4] = *(uint32_t*)&dc->mem_dirty_tbl[ra + 4];
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][8] = *(uint32_t*)&dc->mem_dirty_tbl[ra + 12];
+    *(uint32_t*)&dc->xmm_dirty_tbl[i][12] = *(uint32_t*)&dc->mem_dirty_tbl[ra + 12];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_mem_oo_assign_dup_mo64:
+    ra = DEQ_FROM_ADDR();
+    ra = (ra < phys_ram_size) ? ra : clean_source;
+    i = rec.v1.r2m_m2r.reg;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+    dt[1] = *(uint64_t*)&dc->xmm_dirty_tbl[i][8];
+
+    st[0] = *(uint64_t*)&dc->mem_dirty_tbl[ra];
+
+    dift_log( "Q O %s%s(%" PRIx64 "%" PRIx64 ") %s%s %s[%p](%" PRIx64 ") LD",
+            (dt[1] | dt[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[1], dt[0],
+            DIFT_DEBUG_COLOR_OPERATOR,
+            DIFT_DEBUG_OP_ASSIGN,
+            (st[0])? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            ra,
+            st[0] );
+}
+#endif
+
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][0] = *(uint64_t*)&dc->mem_dirty_tbl[ra];
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][8] = *(uint64_t*)&dc->mem_dirty_tbl[ra + 8];
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dift_log( DIFT_DEBUG_COLOR_OPERATOR
+              DIFT_DEBUG_OP_COMPLETE
+              DIFT_DEBUG_COLOR_RESET );
+}
+#endif
+    THREADED_DISPATCH();
+
+rt_xmm_im_clear:
+    i = rec.v1.r2m_m2r.reg;    
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION
+{
+    dt[0] = *(uint64_t*)&dc->xmm_dirty_tbl[i][0];
+    dt[1] = *(uint64_t*)&dc->xmm_dirty_tbl[i][8];
+
+    dift_log( "DQ C %s%s(%" PRIx64 "%" PRIx64 ")",
+            (dt[1] | dt[0]) ? DIFT_DEBUG_COLOR_TAINTED : DIFT_DEBUG_COLOR_CLEAN,
+            XMM_NAME[i],
+            dt[1], dt[0] );
+}
+#endif
+
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][0] = 0;
+    *(uint64_t*)&dc->xmm_dirty_tbl[i][8] = 0;
+
+#if defined(CONFIG_DIFT_DEBUG)
+DIFT_DEBUG_CONDITION 
 {
     dift_log( DIFT_DEBUG_COLOR_OPERATOR 
               DIFT_DEBUG_OP_COMPLETE 

--- a/ext/dift/dift.c
+++ b/ext/dift/dift.c
@@ -104,8 +104,8 @@ uint8_t case_mapping[1 << (sizeof(uint16_t) * 8)];
 uint16_t case_list[] ={
 
     // encoding:
-    // ((0xc0 | SRC_TYPE | DST_TYPE | OP_SIZE) << 8) | EFFECT)
-    // The sequence should match the ENUM in dift.h
+    // ((0xc0 | SRC_TYPE << 4 | DST_TYPE << 2 | OP_SIZE) << 8) | EFFECT)
+    // NOTE!!! The sequence should match the ENUM in dift.h
     ((0xc0 | OPT_REG << 4 | OPT_REG << 2 | MO_8) << 8) |
                         EFFECT_INSIDE_REG | EFFECT_ASSIGN,  // 0
     ((0xc0 | OPT_REG << 4 | OPT_REG << 2 | MO_8) << 8) |
@@ -228,7 +228,60 @@ uint16_t case_list[] ={
                         EFFECT_CLEAR,                       // 54
 
     ((0xc0 | OPT_IM << 4 | OPT_MEM << 2 | MO_64) << 8) |
-                        EFFECT_CLEAR,                       // 55
+                        EFFECT_CLEAR,                               // 55
+    ((0xc0 | OPT_XMM << 4 | OPT_XMM << 2 | XMM_MO_32) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW, // 56  SSE
+    ((0xc0 | OPT_XMM << 4 | OPT_XMM << 2 | XMM_MO_64) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW, // 57
+    ((0xc0 | OPT_XMM << 4 | OPT_XMM << 2 | XMM_MO_64) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_L2H, // 58
+    ((0xc0 | OPT_XMM << 4 | OPT_XMM << 2 | XMM_MO_64) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_H2L, // 59
+
+
+    ((0xc0 | OPT_XMM << 4 | OPT_XMM << 2 | XMM_MO_128) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW, // 60
+    ((0xc0 | OPT_REG << 4 | OPT_XMM << 2 | XMM_MO_32) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW, // 61
+    ((0xc0 | OPT_REG << 4 | OPT_XMM << 2 | XMM_MO_64) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW, // 62
+    ((0xc0 | OPT_XMM << 4 | OPT_REG << 2 | XMM_MO_32) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW, // 63
+    ((0xc0 | OPT_XMM << 4 | OPT_REG << 2 | XMM_MO_64) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW, // 64
+
+    ((0xc0 | OPT_MEM << 4 | OPT_XMM << 2 | XMM_MO_32) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW, // 65
+    ((0xc0 | OPT_MEM << 4 | OPT_XMM << 2 | XMM_MO_64) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW, // 66
+    ((0xc0 | OPT_MEM << 4 | OPT_XMM << 2 | XMM_MO_64) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_HIGH,// 67   
+    ((0xc0 | OPT_MEM << 4 | OPT_XMM << 2 | XMM_MO_128) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW, // 68
+    ((0xc0 | OPT_XMM << 4 | OPT_MEM << 2 | XMM_MO_32) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW, // 69
+
+    ((0xc0 | OPT_XMM << 4 | OPT_MEM << 2 | XMM_MO_64) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW,                  // 70
+    ((0xc0 | OPT_XMM << 4 | OPT_MEM << 2 | XMM_MO_64) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_HIGH,                 // 71
+    ((0xc0 | OPT_XMM << 4 | OPT_MEM << 2 | XMM_MO_128) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW,                  // 72
+    ((0xc0 | OPT_XMM << 4 | OPT_XMM << 2 | XMM_MO_32) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW | XMM_EFFECT_DUP, // 73
+    ((0xc0 | OPT_XMM << 4 | OPT_XMM << 2 | XMM_MO_32) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_HIGH | XMM_EFFECT_DUP,// 74
+
+    ((0xc0 | OPT_XMM << 4 | OPT_XMM << 2 | XMM_MO_64) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW | XMM_EFFECT_DUP, // 75
+    ((0xc0 | OPT_MEM << 4 | OPT_XMM << 2 | XMM_MO_32) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW | XMM_EFFECT_DUP, // 76
+    ((0xc0 | OPT_MEM << 4 | OPT_XMM << 2 | XMM_MO_32) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_HIGH | XMM_EFFECT_DUP,// 77
+    ((0xc0 | OPT_MEM << 4 | OPT_XMM << 2 | XMM_MO_64) << 8) |
+        XMM_EFFECT_ONE_TO_ONE | XMM_EFFECT_ASSIGN | XMM_EFFECT_LOW | XMM_EFFECT_DUP, // 78
+    ((0xc0 | OPT_IM << 4 | OPT_XMM << 2 | XMM_MO_128) << 8) |
+        XMM_EFFECT_CLEAR,                                                            // 79
 };
 
 uint32_t dift_code_top =  1;  // Loc 0 is reserved for the workaround in add_file_taint
@@ -260,6 +313,11 @@ const char* REG_NAME[] = {
     "R8",  "R9",  "R10", "R11", "R12", "R13", "R14", "R15",
     "RIP", "ES",  "CS",  "SS",  "DS",  "FS",  "GS",  "TMP",
     "NONE"
+};
+
+const char* XMM_NAME[] = {
+    "XMM0", "XMM1", "XMM2", "XMM3", "XMM4", "XMM5", "XMM6", "XMM7",
+    "XMM8", "XMM9", "XMM10", "XMM11", "XMM12", "XMM13", "XMM14", "XMM15"
 };
 
 // Pre-generate routine for DIFT TCG usage


### PR DESCRIPTION
DIFT now performs the taint analysis on SSE movement instructions
Listed are the supported SSE movement instructions:
    movntq,  movntps, lddqu,    movntss,
    movntsd, movd,    movq,     movups,
    movupd,  movaps,  movapd,   movdqa,
    movdqu,  movss,   movsd,    movlps,
    movlpd,  movhlps, movsldup, movddup,
    movhps,  movhpd,  movlhps,  movshdup